### PR TITLE
Fix for autodiscover call on Django 4.2

### DIFF
--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -315,6 +315,7 @@ def autodiscover():
         except (AttributeError, ImportError):
             continue
         try:
+            app_path = list(app_path) if app_path else None
             imp.find_module('tasks', app_path)
         except ImportError:
             continue


### PR DESCRIPTION
Fixes `autodiscover` by properly casting `app_path` before calling `find_module`.

This avoids `app_path` being of type `<class '_frozen_importlib_external._NamespacePath'>`and hence avoiding a runtime error on django 4.2.

Tested it locally by calling `python manage.py process_tasks` and they have run successfully after the code change.