### PR TITLE
correct logic in lock check to fix async mode lockup bug

### DIFF
--- a/background_task/models.py
+++ b/background_task/models.py
@@ -75,7 +75,7 @@ class TaskManager(models.Manager):
         max_run_time = app_settings.BACKGROUND_TASK_MAX_RUN_TIME
         qs = self.get_queryset()
         expires_at = now - timedelta(seconds=max_run_time)
-        locked = Q(locked_by__isnull=False) | Q(locked_at__gt=expires_at)
+        locked = Q(locked_by__isnull=False) & Q(locked_at__gt=expires_at)
         return qs.filter(locked)
 
     def failed(self):


### PR DESCRIPTION
This PR fixes a bug when BACKGROUND_TASK_RUN_ASYNC=True and BACKGROUND_TASK_ASYNC_THREADS=# where # of tasks have been marked locked but are never considered unlocked due to expiration, causing all task processing to cease until the tasks are manually deleted.

locked() and unlocked() currently return conflicting sets of tasks, where certain tasks are returned by both locked() and unlocked(), due to a logic error in the query set. This leads to a state where a number of tasks equal to BACKGROUND_TASK_ASYNC_THREADS are all marked locked_by but are not running and the lock has expired, yet the count of tasks available to be run in asynchronous mode will always be non-positive which blocks further processing.

The fix is to invert the logic of locked criteria: locked_by must be present AND expires_at must be greater than locked_at. Otherwise, locked_by always takes precedent and all tasks that have been locked will remain locked indefinitely.