### PR TITLE
use a django query cursor iterator to load tasks

### DIFF
--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -244,8 +244,12 @@ class DBTaskRunner(object):
 
     def get_task_to_run(self, tasks, queue=None):
         try:
-            available_tasks = [task for task in Task.objects.find_available(queue)
-                               if task.task_name in tasks._tasks][:5]
+            available_tasks = list()
+            for task in Task.objects.find_available(queue).iterator():
+                if task.task_name in tasks._tasks:
+                    available_tasks.append(task)
+                if len(available_tasks) >= 5:
+                    break
             for task in available_tasks:
                 # try to lock task
                 locked_task = task.lock(self.worker_name)


### PR DESCRIPTION
I ran into a project using django4-background-tasks that had a giant tasks table. I noticed that when I would start my task processor, the python process's memory usage was about the same as the size of the tasks table.

Iterating directly over a Django query cursor can load the entire result set into memory. Using [Django's](https://docs.djangoproject.com/en/5.2/ref/models/querysets/#iterator) query cursor `.iterator()` method avoids loading the entire tasks table into memory.